### PR TITLE
auto-generate the IdP config for local clients

### DIFF
--- a/backend/EventManagement.WebApp/Configuration/IdentityServerConfig.cs
+++ b/backend/EventManagement.WebApp/Configuration/IdentityServerConfig.cs
@@ -1,4 +1,7 @@
-﻿using IdentityServer4.Models;
+﻿using EventManagement.Identity;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 
 namespace EventManagement.WebApp
@@ -25,7 +28,11 @@ namespace EventManagement.WebApp
             };
         }
 
-        public static IEnumerable<Client> GetClients()
+        /// <summary>
+        /// Returns a list of local clients that run under
+        /// the same host as the identity provider.
+        /// </summary>
+        public static IEnumerable<Client> GetLocalClients()
         {
             return new List<Client>
             {
@@ -37,15 +44,26 @@ namespace EventManagement.WebApp
                     RequireConsent = false,
 
                     RedirectUris = {
-                        "http://localhost:5000/auth-callback",
-                        "http://localhost:5000/silent-refresh.html"
+                        "~/auth-callback",
+                        "~/silent-refresh.html"
                     },
-                    PostLogoutRedirectUris = { "http://localhost:5000/" },
+                    PostLogoutRedirectUris = { "~" },
 
                     AllowedGrantTypes = GrantTypes.Implicit,
                     AllowedScopes = { "openid", "profile", "eventmanagement.admin" }
                 }
             };
+        }
+    }
+
+    /// <summary>
+    /// Client store to provide the hard-coded local api clients.
+    /// </summary>
+    public class EventManagementLocalClientStore : LocalClientStore
+    {
+        public EventManagementLocalClientStore(IHttpContextAccessor httpContextAccessor)
+            : base(new InMemoryClientStore(IdentityServerConfig.GetLocalClients()), httpContextAccessor)
+        {
         }
     }
 }

--- a/backend/EventManagement.WebApp/Startup.cs
+++ b/backend/EventManagement.WebApp/Startup.cs
@@ -52,7 +52,7 @@ namespace EventManagement.WebApp
                 .AddDeveloperSigningCredential(persistKey: true)
                 .AddInMemoryApiResources(IdentityServerConfig.GetApis())
                 .AddInMemoryIdentityResources(IdentityServerConfig.GetIdentityResources())
-                .AddInMemoryClients(IdentityServerConfig.GetClients())
+                .AddClientStore<EventManagementLocalClientStore>()
                 .AddProfileService<UserProfileService>();
             services.AddTransient<IUserStore, UserStore>();
 

--- a/backend/EventManagement/Identity/LocalClientStore.cs
+++ b/backend/EventManagement/Identity/LocalClientStore.cs
@@ -1,0 +1,64 @@
+﻿using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace EventManagement.Identity
+{
+    /// <summary>
+    /// This client store is for the scenario when you have
+    /// clients that run under the same host as IdentityServer.
+    ///
+    /// It allows relative redirects uris (eg: '~/oidc-signin')
+    /// and converts them to absolute uris.
+    /// </summary>
+    public class LocalClientStore : IClientStore
+    {
+        private readonly IClientStore _inner;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public LocalClientStore(IClientStore innerClientStore, IHttpContextAccessor httpContextAccessor)
+        {
+            _inner = innerClientStore
+                ?? throw new ArgumentNullException(nameof(innerClientStore));
+            _httpContextAccessor = httpContextAccessor
+                ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        }
+
+        public async Task<Client> FindClientByIdAsync(string clientId)
+        {
+            var client = await _inner.FindClientByIdAsync(clientId);
+            if (client != null)
+            {
+                string baseUri = GetBaseUri();
+                client.RedirectUris = client.RedirectUris
+                    .Select(u => MakeAbsoluteUri(baseUri, u)).ToList();
+                client.PostLogoutRedirectUris = client.PostLogoutRedirectUris
+                    .Select(u => MakeAbsoluteUri(baseUri, u)).ToList();
+            }
+            return client;
+        }
+
+        public static string MakeAbsoluteUri(string baseUri, string relativeUri)
+        {
+            if (relativeUri.StartsWith("~/"))
+            {
+                relativeUri = relativeUri.Substring(2, relativeUri.Length - 2);
+                if (!baseUri.EndsWith('/'))
+                {
+                    baseUri += '/';
+                }
+                return new Uri(new Uri(baseUri), relativeUri).AbsoluteUri;
+            }
+            return relativeUri;
+        }
+
+        private string GetBaseUri()
+        {
+            var request = _httpContextAccessor.HttpContext.Request;
+            return $"{request.Scheme}://{request.Host}{request.PathBase}";
+        }
+    }
+}

--- a/backend/EventManagement/UriHelper.cs
+++ b/backend/EventManagement/UriHelper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace EventManagement
+{
+    public static class UriHelper
+    {
+        /// <summary>
+        /// Combine a base uri and a relative uri.
+        /// </summary>
+        /// <param name="baseUri">a complete uri</param>
+        /// <param name="relativeUri">a relative uri that must begin with '~/'</param>
+        /// <returns>combined absolute uri</returns>
+        public static string MakeAbsoluteUri(string baseUri, string relativeUri)
+        {
+            if (relativeUri.StartsWith("~/"))
+            {
+                relativeUri = relativeUri.Substring(2, relativeUri.Length - 2);
+                if (!baseUri.EndsWith('/'))
+                {
+                    baseUri += '/';
+                }
+                return new Uri(new Uri(baseUri), relativeUri).AbsoluteUri;
+            }
+            return relativeUri;
+        }
+    }
+}

--- a/test/EventManagement.UnitTests/UriHelperTests.cs
+++ b/test/EventManagement.UnitTests/UriHelperTests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace EventManagement.UnitTests
+{
+    public class UriHelperTests
+    {
+        [Theory]
+        [InlineData("http://foo.com/foo", "~/bar", "http://foo.com/foo/bar")]
+        [InlineData("http://foo.com/foo", "~/bar/blub", "http://foo.com/foo/bar/blub")]
+        [InlineData("http://foo.com/foo", "http://foo.com", "http://foo.com")]
+        [InlineData("http://foo.com/foo", "bar", "bar")]
+        [InlineData("http://foo.com/foo", "/bar", "/bar")]
+        public void MakeAbsoluteUri(string baseUri, string relativeUri, string expected)
+        {
+            string newUri = UriHelper.MakeAbsoluteUri(baseUri, relativeUri);
+            newUri.Should().NotBeNull();
+            newUri.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
auto-generate the IdP config for local clients that run under the same host as the IdP.

Redirect URIs and Post Logout URIs must be specified with a leading `~/` to point out that the client is running under the same URL as the IdP.
