### PR TITLE
Fixed setting author information for API Clients (S2S)

### DIFF
--- a/backend/src/ApplicationCore/Identity/PrincipalExtensions.cs
+++ b/backend/src/ApplicationCore/Identity/PrincipalExtensions.cs
@@ -1,11 +1,24 @@
-﻿using IdentityServer4.Extensions;
+﻿using IdentityModel;
+using IdentityServer4.Extensions;
 using System;
+using System.Security.Claims;
 using System.Security.Principal;
 
 namespace EventManagement.Identity
 {
     public static class PrincipalExtensions
     {
+        /// <summary>
+        /// Returns true, if the authenticated identity is a real person.
+        /// Returns false, if it is only an API Client (S2S App) without user context.
+        /// </summary>
+        /// <param name="principal">The authenticated user</param>
+        public static bool IsPerson(this IPrincipal principal)
+        {
+            var id = principal.Identity as ClaimsIdentity;
+            return id.FindFirst(JwtClaimTypes.Subject) != null;
+        }
+
         /// <summary>
         /// Get the current user id.
         /// </summary>


### PR DESCRIPTION
When we authenticate to our REST-API using an Access Token that has been issued for a client only (by client id and secret) without user context, we can't create new tickets using:

`POST /api/tickets`

The API will throw an error message: `sub claim is missing`.

I fixed the bug. Creating tickets as API Client (S2S App) without user context is possible now.