### PR TITLE
Migration from ASP.NET Core 2.2 to 3.1

### DIFF
--- a/backend/src/ApplicationCore/ApplicationCore.csproj
+++ b/backend/src/ApplicationCore/ApplicationCore.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EventManagement.ApplicationCore</RootNamespace>
     <AssemblyName>EventManagement.ApplicationCore</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="3.10.6" />
-    <PackageReference Include="ServiceStack.Common.Core" Version="5.7.0" />
+    <PackageReference Include="ServiceStack.Common.Core" Version="5.10.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Identity/Home/HomeController.cs
+++ b/backend/src/Identity/Home/HomeController.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using IdentityServer4.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
@@ -16,14 +16,12 @@ namespace IdentityServer4.Quickstart.UI
     public class HomeController : Controller
     {
         private readonly IIdentityServerInteractionService _interaction;
-        private readonly IHostingEnvironment _environment;
-        private readonly ILogger _logger;
+        private readonly IWebHostEnvironment _environment;
 
-        public HomeController(IIdentityServerInteractionService interaction, IHostingEnvironment environment, ILogger<HomeController> logger)
+        public HomeController(IIdentityServerInteractionService interaction, IWebHostEnvironment environment, ILogger<HomeController> logger)
         {
             _interaction = interaction;
             _environment = environment;
-            _logger = logger;
         }
 
         /// <summary>

--- a/backend/src/Identity/Identity.csproj
+++ b/backend/src/Identity/Identity.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EventManagement.Identity</RootNamespace>
     <AssemblyName>EventManagement.Identity</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="2.4.0" />
   </ItemGroup>
 

--- a/backend/src/Infrastructure/Infrastructure.csproj
+++ b/backend/src/Infrastructure/Infrastructure.csproj
@@ -1,15 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EventManagement.Infrastructure</RootNamespace>
     <AssemblyName>EventManagement.Infrastructure</AssemblyName>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Data\Migrations\20191226091234_SupportTickets.cs" />
-    <Compile Remove="Data\Migrations\20191226091234_SupportTickets.Designer.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MailKit" Version="2.3.2" />

--- a/backend/src/Web/ClientApp/package-lock.json
+++ b/backend/src/Web/ClientApp/package-lock.json
@@ -500,12 +500,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -520,17 +522,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -647,7 +652,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -659,6 +665,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -673,6 +680,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -680,12 +688,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -704,6 +714,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -784,7 +795,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -796,6 +808,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -917,6 +930,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/backend/src/Web/Controllers/MasterQrCodeController.cs
+++ b/backend/src/Web/Controllers/MasterQrCodeController.cs
@@ -53,8 +53,8 @@ namespace EventManagement.WebApp.Controllers
                 await _context.SaveChangesAsync();
             }
 
-            string loginUrl = Url.ActionAbsoluteUrl<MasterQrCodeLoginController>(
-                nameof(MasterQrCodeLoginController.LoginAsync),
+            string loginUrl = Url.RouteAbsoluteUrl(
+                MasterQrCodeLoginController.LoginRouteName,
                 new { token = masterQrCode.Id.ToString() });
 
             return new QrCodeResult(loginUrl);

--- a/backend/src/Web/Controllers/MasterQrCodeLoginController.cs
+++ b/backend/src/Web/Controllers/MasterQrCodeLoginController.cs
@@ -18,6 +18,7 @@ namespace EventManagement.WebApp.Controllers
     [AllowAnonymous]
     public class MasterQrCodeLoginController : Controller
     {
+        public const string LoginRouteName = "QrCodeLogin";
         private readonly EventsDbContext _context;
         private readonly ILogger _logger;
 
@@ -28,7 +29,7 @@ namespace EventManagement.WebApp.Controllers
             _logger = logger;
         }
 
-        [HttpGet("qrauth/{token}")]
+        [HttpGet("qrauth/{token}", Name = LoginRouteName)]
         public async Task<IActionResult> LoginAsync(string token)
         {
             _logger.LogInformation("Validate token");

--- a/backend/src/Web/Controllers/TicketValidationController.cs
+++ b/backend/src/Web/Controllers/TicketValidationController.cs
@@ -27,6 +27,7 @@ namespace EventManagement.WebApp.Controllers
     [AllowAnonymous]
     public class TicketValidationController : EventManagementController
     {
+        public const string TicketValidationRouteName = "TicketValidation";
         private readonly EventsDbContext _context;
         private readonly ITicketRedirectService _ticketRedirectService;
         private readonly IMapper _mapper;
@@ -68,7 +69,7 @@ namespace EventManagement.WebApp.Controllers
         /// </summary>
         /// <param name="secret">The secret key that was stored within the URL.</param>
         /// <returns>result page that tells whether the ticket was valid or not.</returns>
-        [HttpGet("v/{secret}")]
+        [HttpGet("v/{secret}", Name = TicketValidationRouteName)]
         public async Task<IActionResult> ValidateTicketByQrCodeValueAsync(string secret)
         {
             if (secret == null)

--- a/backend/src/Web/Program.cs
+++ b/backend/src/Web/Program.cs
@@ -1,7 +1,7 @@
 using EventManagement.Infrastructure.Data;
 using EventManagement.WebApp.Configuration;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -13,7 +13,7 @@ namespace EventManagement.WebApp
     {
         public static void Main(string[] args)
         {
-            var host = CreateWebHostBuilder(args).Build();
+            var host = CreateHostBuilder(args).Build();
 
             using (var scope = host.Services.CreateScope())
             {
@@ -23,22 +23,27 @@ namespace EventManagement.WebApp
             host.Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .ConfigureLogging(logging =>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Microsoft.Extensions.Hosting.Host
+                .CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    // Enables the "Log stream" feature of Azure App Service.
-                    logging.AddAzureWebAppDiagnostics();
+                    webBuilder
+                        .UseStartup<Startup>()
+                        .ConfigureLogging(logging =>
+                        {
+                            // Enables the "Log stream" feature of Azure App Service.
+                            logging.AddAzureWebAppDiagnostics();
 
-                    // Enables logging to the Hangfire Dashboard Console.
-                    logging.AddHangfireConsole();
+                            // Enables logging to the Hangfire Dashboard Console.
+                            logging.AddHangfireConsole();
+                        });
                 });
 
         private static void SetupDatabase(IServiceProvider services)
         {
             var logger = services.GetRequiredService<ILogger<Program>>();
-            var env = services.GetRequiredService<IHostingEnvironment>();
+            var env = services.GetRequiredService<IWebHostEnvironment>();
             try
             {
                 var dbContext = services.GetRequiredService<EventsDbContext>();

--- a/backend/src/Web/Properties/launchSettings.json
+++ b/backend/src/Web/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:52309",
-      "sslPort": 0
+      "sslPort": 44308
     }
   },
   "profiles": {
@@ -13,7 +13,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:5000;https://localhost:5001"
     },
     "IISExpress": {
       "commandName": "IISExpress",

--- a/backend/src/Web/Shared/Mvc/EventManagementController.cs
+++ b/backend/src/Web/Shared/Mvc/EventManagementController.cs
@@ -24,8 +24,8 @@ namespace EventManagement.WebApp.Shared.Mvc
         /// </summary>
         protected string GetTicketValidationUri(string secret)
         {
-            return Url.ActionAbsoluteUrl<TicketValidationController>(
-                nameof(TicketValidationController.ValidateTicketByQrCodeValueAsync),
+            return Url.RouteAbsoluteUrl(
+                TicketValidationController.TicketValidationRouteName,
                 new { secret = secret });
         }
 

--- a/backend/src/Web/Shared/Mvc/UrlHelperExtensions.cs
+++ b/backend/src/Web/Shared/Mvc/UrlHelperExtensions.cs
@@ -1,24 +1,28 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using System.Text.RegularExpressions;
 
 namespace EventManagement.WebApp.Shared.Mvc
 {
     public static class UrlHelperExtensions
     {
         /// <summary>
-        /// Generates an absolute url to the controller action.
+        /// Generates an absolute url for the given named route.
         /// </summary>
-        public static string ActionAbsoluteUrl<TController>(
-            this IUrlHelper helper, string action, object values)
-            where TController : ControllerBase
+        /// <remarks>
+        /// You have to use the Route-attribute in the controller class specifying a name for the route.
+        /// Example:
+        /// <c>[Route("foo/bar", Name = "routeName")]</c>
+        /// </remarks>
+        public static string RouteAbsoluteUrl(this IUrlHelper helper, string routeName, object values)
         {
             // this makes sure that an absolute url is created.
             string protocol = helper.ActionContext.HttpContext.Request.Scheme;
 
-            string controllerName = Regex.Replace(
-                typeof(TController).Name, "controller$", "", RegexOptions.IgnoreCase);
-
-            return helper.Action(action, controllerName, values, protocol);
+            return helper.RouteUrl(new Microsoft.AspNetCore.Mvc.Routing.UrlRouteContext
+            {
+                Protocol = protocol,
+                RouteName = routeName,
+                Values = values
+            });
         }
     }
 }

--- a/backend/src/Web/Web.csproj
+++ b/backend/src/Web/Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EventManagement.WebApp</RootNamespace>
     <AssemblyName>EventManagement.WebApp</AssemblyName>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
@@ -12,14 +12,15 @@
     <!-- Set this to true if you enable server-side prerendering -->
     <BuildServerSideRenderer>false</BuildServerSideRenderer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591,CS1573</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Fop" Version="1.0.1.3" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.14" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.2.5" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.0.4" />
     <PackageReference Include="NSwag.MSBuild" Version="13.0.4">
@@ -27,8 +28,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="IdentityServer4" Version="2.4.0" />
-    <PackageReference Include="codeessentials.WebOptimizer.Dotless" Version="1.0.10" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="1.0.236" />
+    <PackageReference Include="codeessentials.WebOptimizer.Dotless" Version="3.0.1" />
+    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.304" />
     <PackageReference Include="QRCoder" Version="1.3.6" />
     <PackageReference Include="Hangfire.Core" Version="1.7.7" />
     <PackageReference Include="Hangfire.SqlServer" Version="1.7.7" />

--- a/backend/test/UnitTests/UnitTests.csproj
+++ b/backend/test/UnitTests/UnitTests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <RootNamespace>EventManagement.UnitTests</RootNamespace>
   </PropertyGroup>
 

--- a/ticket-generation/src/TicketGeneration/TicketGeneration.csproj
+++ b/ticket-generation/src/TicketGeneration/TicketGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EventManagement.TicketGeneration</RootNamespace>
     <AssemblyName>EventManagement.TicketGeneration</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
### Done
* Migration from ASP.NET Core 2.2 to 3.1, which is the current LTS version (end of support 2022-12-03)
* Made only the necessary changes for ASP.NET Core 3.1

### Planned for future
* Update of 3rd-party Packages in another PR
* Migration of the Angular Frontend from version 7 to 11.